### PR TITLE
chore: Rename ping command to humeur command

### DIFF
--- a/commands/humeur.js
+++ b/commands/humeur.js
@@ -2,7 +2,7 @@ const { SlashCommandBuilder, AttachmentBuilder } = require('discord.js');
 const drawHumeur = require('../src/generateImage.js')
 module.exports = {
     data: new SlashCommandBuilder()
-        .setName('ping')
+        .setName('humeur')
         .addStringOption(option =>
             option.setName('humeur')
                 .setDescription('Votre humeur, happy, neutral, sad')


### PR DESCRIPTION
This commit renames the `ping` command to `humeur` command in the `commands` directory. The purpose of this change is to align the command name with its functionality, allowing users to specify their mood (happy, neutral, sad) when using the command.